### PR TITLE
Fix mal statistics display

### DIFF
--- a/main.js
+++ b/main.js
@@ -3802,7 +3802,14 @@ class MalApi {
         break;
         
       case 'stats':
-        // No additional params needed for user stats
+        // Request required user statistics fields from MAL API
+        params.fields = [
+          'id',
+          'name',
+          'picture',
+          'anime_statistics',
+          'manga_statistics'
+        ].join(',');
         break;
     }
     
@@ -4065,16 +4072,42 @@ class MalApi {
   }
 
   transformUser(malUser) {
+    const animeStats = malUser?.anime_statistics || {};
+    const mangaStats = malUser?.manga_statistics || {};
+
+    const countAnime = animeStats.num_items || 0;
+    const countManga = mangaStats.num_items || 0;
+
+    const minutesWatched = typeof animeStats.num_days_watched === 'number'
+      ? Math.round(animeStats.num_days_watched * 24 * 60)
+      : 0;
+
     return {
-      id: malUser.id || null,
-      name: malUser.name || 'Unknown User',
+      id: malUser?.id || null,
+      name: malUser?.name || 'Unknown User',
       avatar: {
-        large: malUser.picture || null,
-        medium: malUser.picture || null
+        large: malUser?.picture || null,
+        medium: malUser?.picture || null
+      },
+      mediaListOptions: {
+        // MAL uses 10-point integer scoring
+        scoreFormat: 'POINT_10'
       },
       statistics: {
-        anime: { count: 0, meanScore: 0, standardDeviation: 0, episodesWatched: 0, minutesWatched: 0 },
-        manga: { count: 0, meanScore: 0, standardDeviation: 0, chaptersRead: 0, volumesRead: 0 }
+        anime: {
+          count: countAnime,
+          meanScore: animeStats.mean_score || 0,
+          standardDeviation: 0,
+          episodesWatched: animeStats.num_episodes || 0,
+          minutesWatched: minutesWatched
+        },
+        manga: {
+          count: countManga,
+          meanScore: mangaStats.mean_score || 0,
+          standardDeviation: 0,
+          chaptersRead: mangaStats.num_chapters || 0,
+          volumesRead: mangaStats.num_volumes || 0
+        }
       }
     };
   }
@@ -4747,26 +4780,27 @@ class SimklApi {
   // =================== DATA TRANSFORMATION ===================
 
   transformResponse(data, config) {
-  switch (config.type) {
-    case 'search':
-      return { Page: { media: data.data?.map(item => this.transformMedia(item)) || [] } };
-    case 'single':
-      const targetMedia = data.data?.find(item => item.node.id === parseInt(config.mediaId));
-      return { MediaList: targetMedia ? this.transformListEntry(targetMedia) : null };
-    case 'stats':
-      return { User: this.transformUser(data) };
-    default:
-      return {
-        MediaListCollection: {
-          lists: [{ 
-            entries: data.data?.map(item => {
-              // Debug log the actual item structure
-              console.log('Raw MAL item before transform:', JSON.stringify(item, null, 2));
-              return this.transformListEntry(item);
-            }) || [] 
-          }]
-        }
-      };
+    switch (config.type) {
+      case 'search':
+        return { Page: { media: data.data?.map(item => this.transformMedia(item)) || [] } };
+      case 'single':
+        const targetMedia = data.data?.find(item => item.node.id === parseInt(config.mediaId));
+        return { MediaList: targetMedia ? this.transformListEntry(targetMedia) : null };
+      case 'stats':
+        return { User: this.transformUser(data) };
+      default:
+        return {
+          MediaListCollection: {
+            lists: [{ 
+              entries: data.data?.map(item => {
+                // Debug log the actual item structure
+                console.log('Raw MAL item before transform:', JSON.stringify(item, null, 2));
+                return this.transformListEntry(item);
+              }) || [] 
+            }]
+          }
+        };
+    }
   }
 }
   transformSearchResponse(data) {
@@ -7208,7 +7242,11 @@ class StatsRenderer {
     // Make the user name clickable
     userName.style.cursor = 'pointer';
     userName.addEventListener('click', () => {
-      window.open(`https://anilist.co/user/${user.name}`, '_blank');
+      const source = user?._zoroMeta?.source || 'anilist';
+      const url = source === 'mal'
+        ? `https://myanimelist.net/profile/${encodeURIComponent(user.name)}`
+        : `https://anilist.co/user/${encodeURIComponent(user.name)}`;
+      window.open(url, '_blank');
     });
 
     userName.addEventListener('mouseenter', () => {


### PR DESCRIPTION
Enable full MAL user statistics display by fetching and mapping relevant data from the MAL API.

Previously, MAL user statistics were not correctly fetched or transformed, resulting in only the profile image being displayed. This PR updates the MAL API query to request `anime_statistics` and `manga_statistics` fields, and enhances the `transformUser` method to correctly populate the statistics object. It also ensures the profile link in the stats header correctly points to MyAnimeList for MAL users.

---
<a href="https://cursor.com/background-agent?bcId=bc-6801f26c-8752-4839-91d1-c348f0c2bdaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6801f26c-8752-4839-91d1-c348f0c2bdaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

