### PR TITLE
Fix MyAnimeList manga and AniList score display

### DIFF
--- a/main.js
+++ b/main.js
@@ -3775,6 +3775,8 @@ class MalApi {
       status: status,
       score: score,
       progress: progress,
+      chaptersRead: listStatus?.num_chapters_read ?? null,
+      volumesRead: listStatus?.num_volumes_read ?? null,
       media: this.transformMedia(malEntry)
     };
   }
@@ -4395,6 +4397,41 @@ manga: {
     if (user?.statistics?.manga) {
       Object.assign(user.statistics.manga, mangaAgg);
     }
+
+    // Fallbacks when API doesn't fully populate statistics
+    const applyFallbacks = (entries, statsObj, type) => {
+      if (!statsObj) return;
+
+      // Count
+      if (!statsObj.count || statsObj.count === 0) {
+        statsObj.count = Array.isArray(entries) ? entries.length : 0;
+      }
+
+      // Mean score (entries score are 0-10; UI expects 0-100)
+      if ((!statsObj.meanScore || statsObj.meanScore === 0) && Array.isArray(entries) && entries.length) {
+        const rated = entries.filter(e => typeof e.score === 'number' && e.score > 0);
+        if (rated.length) {
+          const avg10 = rated.reduce((sum, e) => sum + e.score, 0) / rated.length;
+          statsObj.meanScore = Math.round(avg10 * 10);
+        }
+      }
+
+      if (type === 'manga') {
+        if (!statsObj.chaptersRead || statsObj.chaptersRead === 0) {
+          statsObj.chaptersRead = entries.reduce((s, e) => s + (e.chaptersRead || 0), 0);
+        }
+        if (!statsObj.volumesRead || statsObj.volumesRead === 0) {
+          statsObj.volumesRead = entries.reduce((s, e) => s + (e.volumesRead || 0), 0);
+        }
+      } else if (type === 'anime') {
+        if (!statsObj.episodesWatched || statsObj.episodesWatched === 0) {
+          statsObj.episodesWatched = entries.reduce((s, e) => s + (e.progress || 0), 0);
+        }
+      }
+    };
+
+    applyFallbacks(animeEntries, user?.statistics?.anime, 'anime');
+    applyFallbacks(mangaEntries, user?.statistics?.manga, 'manga');
   } catch (e) {
   }
 }
@@ -7682,7 +7719,12 @@ if (showManga && mangaStats && mangaStats.count > 0) {
       const barContainer = chart.createDiv({ cls: 'zoro-score-bar-container' });
       
       const label = barContainer.createDiv({ cls: 'zoro-score-label' });
-      label.textContent = this.formatter.formatScore(scoreData.score, listOptions?.scoreFormat);
+      const scoreFormat = listOptions?.scoreFormat || 'POINT_10';
+      let scoreValue = scoreData.score;
+      if (scoreFormat === 'POINT_10' && typeof scoreValue === 'number' && scoreValue <= 10) {
+        scoreValue = scoreValue * 10;
+      }
+      label.textContent = this.formatter.formatScore(scoreValue, scoreFormat);
       
       const bar = barContainer.createDiv({ cls: 'zoro-score-bar' });
       const percentage = (scoreData.count / maxCount) * 100;


### PR DESCRIPTION
Restore full MyAnimeList Manga stats display and correct AniList score distribution labels.

MAL Manga stats now compute fully from list entries if the user endpoint lacks data, ensuring average score, distributions, and totals are always shown. AniList score distribution labels now correctly scale 1-10 scores to 10-100 for display (e.g., 7/10 instead of 0.7/10).

---
<a href="https://cursor.com/background-agent?bcId=bc-ae417c5d-73d4-4351-89f2-e86fc592cd12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae417c5d-73d4-4351-89f2-e86fc592cd12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

