### PR TITLE
Fix more detail panel using tmdb id

### DIFF
--- a/src/details/DetailPanelSource.js
+++ b/src/details/DetailPanelSource.js
@@ -98,6 +98,12 @@ class DetailPanelSource {
       return true;
     }
     
+    // Also check if the entry object has a media property with TMDb source
+    if (entry?.media?._zoroMeta?.source === 'tmdb' && (entry?.media?._zoroMeta?.mediaType === 'MOVIE' || entry?.media?._zoroMeta?.mediaType === 'TV')) {
+      console.log('[DetailPanelSource] TMDb source detected from entry.media._zoroMeta, returning true');
+      return true;
+    }
+    
     const result = missingBasicData || isAnimeWithoutAiring;
     console.log('[DetailPanelSource] Final result:', result, { missingBasicData, isAnimeWithoutAiring });
     return result;

--- a/src/details/DetailPanelSource.js
+++ b/src/details/DetailPanelSource.js
@@ -67,18 +67,43 @@ class DetailPanelSource {
     return typeMap[normalizedType] || null;
   }
 
-  shouldFetchDetailedData(media) {
+  shouldFetchDetailedData(media, entry = null) {
     const missingBasicData = !media.description || !media.genres || !media.averageScore;
     const isAnimeWithoutAiring = media.type === 'ANIME' && !media.nextAiringEpisode;
+    
+    // For TMDb trending items, always fetch detailed data to get additional information
+    if (media._zoroMeta?.source === 'tmdb' && (media._zoroMeta?.mediaType === 'MOVIE' || media._zoroMeta?.mediaType === 'TV')) {
+      return true;
+    }
+    
+    // Also check the entry object for source information
+    if (entry?._zoroMeta?.source === 'tmdb' && (entry?._zoroMeta?.mediaType === 'MOVIE' || entry?._zoroMeta?.mediaType === 'TV')) {
+      return true;
+    }
+    
     return missingBasicData || isAnimeWithoutAiring;
   }
 
   extractSourceFromEntry(entry) {
-    return entry?._zoroMeta?.source || this.plugin.settings.defaultApiSource || 'anilist';
+    // For trending items, the source might be in the media object's _zoroMeta
+    if (entry?._zoroMeta?.source) {
+      return entry._zoroMeta.source;
+    }
+    if (entry?.media?._zoroMeta?.source) {
+      return entry.media._zoroMeta.source;
+    }
+    return this.plugin.settings.defaultApiSource || 'anilist';
   }
 
   extractMediaTypeFromEntry(entry) {
-    return entry?._zoroMeta?.mediaType || entry?.media?.type || null;
+    // For trending items, the mediaType might be in the media object's _zoroMeta
+    if (entry?._zoroMeta?.mediaType) {
+      return entry._zoroMeta.mediaType;
+    }
+    if (entry?.media?._zoroMeta?.mediaType) {
+      return entry.media._zoroMeta.mediaType;
+    }
+    return entry?.media?.type || null;
   }
 
   async fetchDetailedData(mediaId, entryOrSource = null, mediaType = null) {
@@ -138,6 +163,33 @@ class DetailPanelSource {
         }
         // Fallback to original media data if detailed fetch fails
         return entryOrSource.media;
+              } else {
+          return null;
+        }
+    } else if (source === 'tmdb' && (resolvedMediaType === 'MOVIE' || resolvedMediaType === 'TV')) {
+      // For TMDb movies and TV shows, fetch detailed data from TMDb API
+      // For TMDb trending items, mediaId is the TMDb ID
+      const tmdbId = entryOrSource?.media?.idTmdb || mediaId;
+      if (tmdbId) {
+        const detailedTmdbData = await this.fetchTmdbDetailedData(tmdbId, resolvedMediaType);
+        if (detailedTmdbData) {
+          // Merge the detailed data with the original media data
+          const originalMedia = entryOrSource?.media || entryOrSource;
+          return {
+            ...originalMedia,
+            ...detailedTmdbData,
+            // Ensure we keep the original ID and other essential fields
+            id: originalMedia.id || mediaId,
+            idImdb: originalMedia.idImdb || detailedTmdbData.external_ids?.imdb_id || null,
+            idTmdb: tmdbId,
+            // Map TMDb overview to description
+            description: detailedTmdbData.overview || originalMedia.description || null,
+            // TMDb doesn't provide airing data in their trending API
+            nextAiringEpisode: null
+          };
+        }
+        // Fallback to original media data if detailed fetch fails
+        return entryOrSource?.media || entryOrSource;
               } else {
           return null;
         }
@@ -269,6 +321,52 @@ class DetailPanelSource {
     }
   }
 
+  async fetchTmdbDetailedData(tmdbId, mediaType) {
+    if (!tmdbId) return null;
+    
+    // Check if TMDb API key is configured
+    if (!this.plugin.settings.tmdbApiKey) {
+      console.error('[DetailPanelSource] TMDb API key not configured');
+      return null;
+    }
+    
+    // Use stable caching system (TMDb doesn't have airing data)
+    const stableCacheKey = this.plugin.cache.structuredKey('tmdb', 'stable', `${tmdbId}_${mediaType}`);
+    const cached = this.plugin.cache.get(stableCacheKey, { scope: 'mediaDetails', source: 'tmdb' });
+    if (cached) return cached;
+
+    try {
+      // Use correct TMDb API endpoints for detailed data
+      const endpoint = mediaType === 'MOVIE' ? 'movie' : 'tv';
+      const url = `https://api.themoviedb.org/3/${endpoint}/${tmdbId}?api_key=${this.plugin.settings.tmdbApiKey}&append_to_response=external_ids,credits,videos,images`;
+      
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`TMDb API error: ${response.status}`);
+      const data = await response.json();
+      
+      if (data) {
+        // TMDb does not provide airing data in their trending API
+        // Remove any next_episode field if it exists (it shouldn't)
+        if (data.next_episode) {
+          delete data.next_episode;
+        }
+        
+        // Cache stable data using cache class TTL
+        this.plugin.cache.set(stableCacheKey, data, { 
+          scope: 'mediaDetails', 
+          source: 'tmdb', 
+          tags: ['tmdb', 'details', 'stable', endpoint] 
+        });
+        
+        return data;
+      }
+      return null;
+    } catch (error) {
+      console.error('[DetailPanelSource] TMDb fetch failed:', error);
+      return null;
+    }
+  }
+
 
 
 
@@ -379,6 +477,11 @@ class DetailPanelSource {
       
       // For Simkl movies/TV, fetch IMDB data
       if (source === 'simkl' && (mediaType === 'MOVIE' || mediaType === 'TV') && detailedMedia.idImdb) {
+        imdbDataPromise = this.fetchIMDBData(detailedMedia.idImdb, detailedMedia.type, detailedMedia);
+      }
+      
+      // For TMDb movies/TV, fetch IMDB data
+      if (source === 'tmdb' && (mediaType === 'MOVIE' || mediaType === 'TV') && detailedMedia.idImdb) {
         imdbDataPromise = this.fetchIMDBData(detailedMedia.idImdb, detailedMedia.type, detailedMedia);
       }
       

--- a/src/details/OpenDetailPanel.js
+++ b/src/details/OpenDetailPanel.js
@@ -16,11 +16,17 @@ class OpenDetailPanel {
 			media: { 
 				id: media?.id, 
 				type: media?.type, 
-				_zoroMeta: media?._zoroMeta 
+				_zoroMeta: media?._zoroMeta,
+				idTmdb: media?.idTmdb,
+				ids: media?.ids
 			}, 
 			entry: { 
 				_zoroMeta: entry?._zoroMeta,
-				media: entry?.media?._zoroMeta
+				media: {
+					_zoroMeta: entry?.media?._zoroMeta,
+					idTmdb: entry?.media?.idTmdb,
+					ids: entry?.media?.ids
+				}
 			} 
 		});
 		

--- a/src/details/OpenDetailPanel.js
+++ b/src/details/OpenDetailPanel.js
@@ -12,6 +12,18 @@ class OpenDetailPanel {
 	}
 
 	async showPanel(media, entry = null, triggerElement) {
+		console.log('[OpenDetailPanel] showPanel called with:', { 
+			media: { 
+				id: media?.id, 
+				type: media?.type, 
+				_zoroMeta: media?._zoroMeta 
+			}, 
+			entry: { 
+				_zoroMeta: entry?._zoroMeta,
+				media: entry?.media?._zoroMeta
+			} 
+		});
+		
 		this.closePanel();
 		const panel = this.renderer.createPanel(media, entry);
 		this.currentPanel = panel;
@@ -22,11 +34,17 @@ class OpenDetailPanel {
 		document.addEventListener('click', this.boundOutsideClickHandler);
 		this.plugin.requestQueue.showGlobalLoader();
 
-		if (this.dataSource.shouldFetchDetailedData(media, entry)) {
+		const shouldFetch = this.dataSource.shouldFetchDetailedData(media, entry);
+		console.log('[OpenDetailPanel] shouldFetchDetailedData result:', shouldFetch);
+		
+		if (shouldFetch) {
+			console.log('[OpenDetailPanel] Fetching detailed data for media ID:', media.id);
 			this.dataSource.fetchAndUpdateData(media.id, entry, (detailedMedia, malData, imdbData) => {
+				console.log('[OpenDetailPanel] Detailed data received:', { detailedMedia, malData, imdbData });
 				if (this.currentPanel === panel) this.renderer.updatePanelContent(panel, detailedMedia, malData, imdbData);
 			}).finally(() => this.plugin.requestQueue.hideGlobalLoader());
 		} else {
+			console.log('[OpenDetailPanel] Not fetching detailed data');
 			this.plugin.requestQueue.hideGlobalLoader();
 		}
 		return panel;

--- a/src/details/OpenDetailPanel.js
+++ b/src/details/OpenDetailPanel.js
@@ -22,7 +22,7 @@ class OpenDetailPanel {
 		document.addEventListener('click', this.boundOutsideClickHandler);
 		this.plugin.requestQueue.showGlobalLoader();
 
-		if (this.dataSource.shouldFetchDetailedData(media)) {
+		if (this.dataSource.shouldFetchDetailedData(media, entry)) {
 			this.dataSource.fetchAndUpdateData(media.id, entry, (detailedMedia, malData, imdbData) => {
 				if (this.currentPanel === panel) this.renderer.updatePanelContent(panel, detailedMedia, malData, imdbData);
 			}).finally(() => this.plugin.requestQueue.hideGlobalLoader());

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -498,6 +498,13 @@ class Trending {
           item._zoroMeta.mediaType = config.mediaType || 'ANIME';
           item._zoroMeta.fetchedAt = Date.now();
         }
+        
+        console.log('[Trending] Item _zoroMeta set:', { 
+          itemId: item.id, 
+          source: item._zoroMeta.source, 
+          mediaType: item._zoroMeta.mediaType,
+          isTmdb 
+        });
       });
 
       el.empty();

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -267,6 +267,7 @@ class Trending {
         },
         releaseDate: isMovie ? item.release_date : item.first_air_date,
         _zoroMeta: {
+          source: 'tmdb',
           mediaType: mediaType.toUpperCase(),
           fetchedAt: Date.now(),
           trending: {

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -184,6 +184,12 @@ class Trending {
         .slice(0, limit)
         .map(item => this.transformTMDbMedia(item, mediaType))
         .filter(Boolean);
+      
+      console.log('[Trending] fetchTMDbTrending created mediaList with items:', mediaList.map(item => ({
+        id: item.id,
+        source: item._zoroMeta?.source,
+        mediaType: item._zoroMeta?.mediaType
+      })));
 
       try {
         const idsToFetch = mediaList.map(m => m.idTmdb).filter(Boolean).slice(0, 20);
@@ -235,7 +241,7 @@ class Trending {
     try {
       const isMovie = mediaType.toUpperCase() === 'MOVIE' || mediaType.toUpperCase() === 'MOVIES';
       
-      return {
+      const transformedItem = {
         id: item.id,
         idTmdb: item.id,
         idImdb: null,
@@ -277,6 +283,14 @@ class Trending {
           }
         }
       };
+      
+      console.log('[Trending] transformTMDbMedia created item with _zoroMeta:', {
+        itemId: transformedItem.id,
+        source: transformedItem._zoroMeta.source,
+        mediaType: transformedItem._zoroMeta.mediaType
+      });
+      
+      return transformedItem;
     } catch (error) {
       console.error('[Trending] Failed to transform TMDb item:', item, error);
       return null;
@@ -487,6 +501,8 @@ class Trending {
 
       items.forEach(item => {
         const isTmdb = ['MOVIE','MOVIES','TV','SHOW','SHOWS'].includes((config.mediaType || '').toUpperCase());
+        
+        // For TMDb items, preserve the existing _zoroMeta.source if it's already set
         if (!item._zoroMeta) {
           item._zoroMeta = {
             source: isTmdb ? 'tmdb' : source,
@@ -494,7 +510,10 @@ class Trending {
             fetchedAt: Date.now()
           };
         } else {
-          item._zoroMeta.source = isTmdb ? 'tmdb' : source;
+          // Only override source if it's not already set to 'tmdb'
+          if (item._zoroMeta.source !== 'tmdb') {
+            item._zoroMeta.source = isTmdb ? 'tmdb' : source;
+          }
           item._zoroMeta.mediaType = config.mediaType || 'ANIME';
           item._zoroMeta.fetchedAt = Date.now();
         }
@@ -503,7 +522,8 @@ class Trending {
           itemId: item.id, 
           source: item._zoroMeta.source, 
           mediaType: item._zoroMeta.mediaType,
-          isTmdb 
+          isTmdb,
+          originalSource: item._zoroMeta.source
         });
       });
 

--- a/src/rendering/renderers/CardRenderer.js
+++ b/src/rendering/renderers/CardRenderer.js
@@ -86,6 +86,10 @@ class CardRenderer {
       
       pressTimer = setTimeout(() => {
         if (isPressed) {
+          console.log('[CardRenderer] Opening detail panel for:', { 
+            media: { id: media?.id, type: media?.type, _zoroMeta: media?._zoroMeta },
+            entry: { _zoroMeta: entry?._zoroMeta, media: entry?.media?._zoroMeta }
+          });
           this.plugin.moreDetailsPanel.showPanel(media, entry, img);
           img.classList.remove('pressed');
           isPressed = false;
@@ -125,6 +129,10 @@ class CardRenderer {
       pressTimer = setTimeout(() => {
         if (isPressed) {
           e.preventDefault();
+          console.log('[CardRenderer] Opening detail panel for (touch):', { 
+            media: { id: media?.id, type: media?.type, _zoroMeta: media?._zoroMeta },
+            entry: { _zoroMeta: entry?._zoroMeta, media: entry?.media?._zoroMeta }
+          });
           this.plugin.moreDetailsPanel.showPanel(media, entry, img);
           img.classList.remove('pressed');
           isPressed = false;


### PR DESCRIPTION
Enable the more detail panel for TMDb trending movies and TV shows by fetching data using TMDb IDs instead of Simkl IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6584f3e-ba37-4b46-bf17-2d02ce5234d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6584f3e-ba37-4b46-bf17-2d02ce5234d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

