### PR TITLE
Prevent code block insertion for trending notes

### DIFF
--- a/cmp/main.js
+++ b/cmp/main.js
@@ -11049,11 +11049,10 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Disable code block for trending Movie/TV entries regardless of source
+    // Always disable code block for Movie/TV entries regardless of source or context
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
-    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
-    if (isMovieOrTv && isTrending) {
+    if (isMovieOrTv) {
       return '';
     }
 

--- a/cmp/main.js
+++ b/cmp/main.js
@@ -10767,6 +10767,7 @@ class ConnectedNotes {
     this.currentUrls = null; // Store current URLs as array for matching
     this.currentSource = null; // Store current source for code block generation
     this.currentMediaType = null; // Store current media type for code block generation
+    this.isTrendingContext = false; // Track if current action comes from a trending view
   }
 
    /**
@@ -11048,10 +11049,11 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Disable code block for TMDb trending (movies/TV) since single render is not supported
-    const src = String(this.currentSource || '').toLowerCase();
+    // Disable code block for trending Movie/TV entries regardless of source
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
-    if (src === 'tmdb' && (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS')) {
+    const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
+    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return '';
     }
 
@@ -11653,11 +11655,12 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
   /**
  * Handle connected notes button click
  */
-async handleConnectedNotesClick(e, media, entry, config) {
-  e.preventDefault();
-  e.stopPropagation();
-  
-  try {
+  async handleConnectedNotesClick(e, media, entry, config) {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    try {
+      this.isTrendingContext = Boolean(config?.isTrending);
     // Extract source and media type
     const source = this.plugin.apiHelper ? 
       this.plugin.apiHelper.detectSource(entry, config) : 

--- a/cmp/main.js
+++ b/cmp/main.js
@@ -11049,10 +11049,11 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Always disable code block for Movie/TV entries regardless of source or context
+    // Disable code block for trending Movie/TV entries regardless of source
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
-    if (isMovieOrTv) {
+    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return '';
     }
 

--- a/main.js
+++ b/main.js
@@ -12564,8 +12564,7 @@ var ConnectedNotes = class {
     }
     const typeUpper = String(this.currentMediaType || "").toUpperCase();
     const isMovieOrTv = typeUpper === "MOVIE" || typeUpper === "MOVIES" || typeUpper === "TV" || typeUpper === "SHOW" || typeUpper === "SHOWS";
-    const isTrending = Boolean(this.currentMedia?._zoroMeta?.isTrending);
-    if (isMovieOrTv && isTrending) {
+    if (isMovieOrTv) {
       return "";
     }
     const codeBlockLines = [

--- a/main.js
+++ b/main.js
@@ -12979,6 +12979,7 @@ var ConnectedNotes = class {
     e.preventDefault();
     e.stopPropagation();
     try {
+      this.isTrendingContext = Boolean(config?.isTrending);
       const source = this.plugin.apiHelper ? this.plugin.apiHelper.detectSource(entry, config) : entry?._zoroMeta?.source || config?.source || "anilist";
       const mediaType = this.plugin.apiHelper ? this.plugin.apiHelper.detectMediaType(entry, config, media) : entry?._zoroMeta?.mediaType || config?.mediaType || "ANIME";
       this.currentMedia = media;

--- a/main.js
+++ b/main.js
@@ -12564,7 +12564,8 @@ var ConnectedNotes = class {
     }
     const typeUpper = String(this.currentMediaType || "").toUpperCase();
     const isMovieOrTv = typeUpper === "MOVIE" || typeUpper === "MOVIES" || typeUpper === "TV" || typeUpper === "SHOW" || typeUpper === "SHOWS";
-    if (isMovieOrTv) {
+    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return "";
     }
     const codeBlockLines = [

--- a/main.js
+++ b/main.js
@@ -6923,19 +6923,22 @@ var Trending = class {
           item._zoroMeta = {
             source: isTmdb ? "tmdb" : source,
             mediaType: config.mediaType || "ANIME",
-            fetchedAt: Date.now()
+            fetchedAt: Date.now(),
+            isTrending: true
           };
         } else {
           item._zoroMeta.source = isTmdb ? "tmdb" : source;
           item._zoroMeta.mediaType = config.mediaType || "ANIME";
           item._zoroMeta.fetchedAt = Date.now();
+          item._zoroMeta.isTrending = true;
         }
       });
       el.empty();
       this.plugin.render.renderSearchResults(el, items, {
         layout: config.layout || "card",
         mediaType: config.mediaType || "ANIME",
-        source
+        source,
+        isTrending: true
       });
     } catch (err) {
       console.error("[Trending] Error in renderTrendingBlock:", err);
@@ -12559,9 +12562,10 @@ var ConnectedNotes = class {
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return "";
     }
-    const src = String(this.currentSource || "").toLowerCase();
     const typeUpper = String(this.currentMediaType || "").toUpperCase();
-    if (src === "tmdb" && (typeUpper === "MOVIE" || typeUpper === "MOVIES" || typeUpper === "TV" || typeUpper === "SHOW" || typeUpper === "SHOWS")) {
+    const isMovieOrTv = typeUpper === "MOVIE" || typeUpper === "MOVIES" || typeUpper === "TV" || typeUpper === "SHOW" || typeUpper === "SHOWS";
+    const isTrending = Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return "";
     }
     const codeBlockLines = [

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -932,9 +932,10 @@ async handleConnectedNotesClick(e, media, entry, config) {
     const typeUpper = String(mediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper.includes('SHOW'));
     const isTmdbEntry = (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb' || !!media?.idTmdb;
+    const isTrending = Boolean(entry?._zoroMeta?.isTrending);
     let maskedMedia = media;
     let maskedSource = source;
-    if (isMovieOrTv && isTmdbEntry && this.plugin?.simklApi?.resolveSimklByExternalIds) {
+    if (isTrending && isMovieOrTv && isTmdbEntry && this.plugin?.simklApi?.resolveSimklByExternalIds) {
       const ids = { tmdb: Number(media.idTmdb || media.id) || null, imdb: media.idImdb || null };
       const resolved = await this.plugin.simklApi.resolveSimklByExternalIds(ids, mediaType);
       if (resolved?.simklId) {

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -292,11 +292,10 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Disable code block for trending Movie/TV entries regardless of source
+    // Always disable code block for Movie/TV entries regardless of source or context
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
-    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
-    if (isMovieOrTv && isTrending) {
+    if (isMovieOrTv) {
       return '';
     }
 

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -10,6 +10,7 @@ class ConnectedNotes {
     this.currentUrls = null; // Store current URLs as array for matching
     this.currentSource = null; // Store current source for code block generation
     this.currentMediaType = null; // Store current media type for code block generation
+    this.isTrendingContext = false; // Track if current action comes from a trending view
   }
 
    /**
@@ -294,7 +295,7 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     // Disable code block for trending Movie/TV entries regardless of source
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
-    const isTrending = Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
     if (isMovieOrTv && isTrending) {
       return '';
     }
@@ -902,6 +903,9 @@ async handleConnectedNotesClick(e, media, entry, config) {
   e.stopPropagation();
   
   try {
+    // Mark context as trending if coming from trending rendering
+    this.isTrendingContext = Boolean(config?.isTrending);
+
     // Extract source and media type
     const source = this.plugin.apiHelper ? 
       this.plugin.apiHelper.detectSource(entry, config) : 

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -10,6 +10,7 @@ class ConnectedNotes {
     this.currentUrls = null; // Store current URLs as array for matching
     this.currentSource = null; // Store current source for code block generation
     this.currentMediaType = null; // Store current media type for code block generation
+    this.isTrendingContext = false; // Track if current action comes from a trending view
   }
 
    /**
@@ -735,8 +736,13 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     // Footer section at bottom
     const footer = container.createEl('div', { cls: 'zoro-note-panel-footer' });
     
-    const createButton = footer.createEl('button', { text: '📝', cls: 'zoro-note-create-btn' });
-    createButton.onclick = () => this.createNewConnectedNote(searchIds, mediaType);
+    // Hide create button for trending Movie/TV context
+    const typeUpper = String(mediaType || '').toUpperCase();
+    const hideCreate = this.isTrendingContext && (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper.includes('SHOW'));
+    if (!hideCreate) {
+      const createButton = footer.createEl('button', { text: '📝', cls: 'zoro-note-create-btn' });
+      createButton.onclick = () => this.createNewConnectedNote(searchIds, mediaType);
+    }
     
     // New connect existing button
     const connectButton = footer.createEl('button', { text: '⛓️', cls: 'zoro-note-connect-existing-btn' });
@@ -919,6 +925,8 @@ async handleConnectedNotesClick(e, media, entry, config) {
   e.stopPropagation();
   
   try {
+    // Set trending context based on entry metadata
+    this.isTrendingContext = Boolean(entry?._zoroMeta?.isTrending);
     // Extract source and media type
     const source = this.plugin.apiHelper ? 
       this.plugin.apiHelper.detectSource(entry, config) : 

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -19,6 +19,17 @@ class ConnectedNotes {
 extractSearchIds(media, entry, source) {
   const ids = {};
   
+  // Special case: Trending Movie/TV entries should not be treated as Simkl or other sources
+  try {
+    const typeUpper = String(this.currentMediaType || '').toUpperCase();
+    const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
+    if (this.isTrendingContext && isMovieOrTv) {
+      if (media.idTmdb || media.id) ids.tmdb_id = media.idTmdb || media.id;
+      if (media.idImdb) ids.imdb_id = media.idImdb;
+      return ids;
+    }
+  } catch {}
+  
   // mal_id is STANDARD for all anime/manga regardless of source
   if (source === 'mal') {
     ids.mal_id = media.id;
@@ -62,6 +73,18 @@ extractSearchIds(media, entry, source) {
  */
 buildCurrentUrls(media, mediaType, source) {
   const urls = [];
+  
+  // Special case: Trending Movie/TV entries should only include TMDb/IMDb URLs
+  try {
+    const typeUpper = String(mediaType || '').toUpperCase();
+    const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
+    if (this.isTrendingContext && isMovieOrTv) {
+      const isMovie = typeUpper.includes('MOVIE');
+      if (media.idTmdb || media.id) urls.push(`https://www.themoviedb.org/${isMovie ? 'movie' : 'tv'}/${media.idTmdb || media.id}`);
+      if (media.idImdb) urls.push(`https://www.imdb.com/title/${media.idImdb}/`);
+      return urls;
+    }
+  } catch {}
   
   // Build source-specific URL first
   if (source === 'simkl') {

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -903,8 +903,16 @@ async handleConnectedNotesClick(e, media, entry, config) {
   e.stopPropagation();
   
   try {
-    // Mark context as trending if coming from trending rendering
-    this.isTrendingContext = Boolean(config?.isTrending);
+    // Determine trending context strictly via DOM/data attribute, independent of source
+    let trendingFlag = false;
+    try {
+      const target = e.currentTarget || e.target;
+      const cardEl = target?.closest?.('.zoro-card');
+      if (cardEl && cardEl.dataset && cardEl.dataset.trending === 'true') {
+        trendingFlag = true;
+      }
+    } catch {}
+    this.isTrendingContext = trendingFlag;
 
     // Extract source and media type
     const source = this.plugin.apiHelper ? 

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -292,10 +292,11 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Always disable code block for Movie/TV entries regardless of source or context
+    // Disable code block for trending Movie/TV entries regardless of source
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
     const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
-    if (isMovieOrTv) {
+    const isTrending = this.isTrendingContext || Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return '';
     }
 

--- a/src/features/ConnectedNotes.js
+++ b/src/features/ConnectedNotes.js
@@ -291,10 +291,11 @@ urls.push(`https://myanimelist.net/${malMediaType}/${media.idMal}`);
     if (!this.currentMedia || !this.currentSource || !this.currentMediaType) {
       return ''; // Return empty if missing required data
     }
-    // Disable code block for TMDb trending (movies/TV) since single render is not supported
-    const src = String(this.currentSource || '').toLowerCase();
+    // Disable code block for trending Movie/TV entries regardless of source
     const typeUpper = String(this.currentMediaType || '').toUpperCase();
-    if (src === 'tmdb' && (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS')) {
+    const isMovieOrTv = (typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper === 'SHOW' || typeUpper === 'SHOWS');
+    const isTrending = Boolean(this.currentMedia?._zoroMeta?.isTrending);
+    if (isMovieOrTv && isTrending) {
       return '';
     }
 

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -490,12 +490,14 @@ class Trending {
           item._zoroMeta = {
             source: isTmdb ? 'tmdb' : source,
             mediaType: config.mediaType || 'ANIME',
-            fetchedAt: Date.now()
+            fetchedAt: Date.now(),
+            isTrending: true
           };
         } else {
           item._zoroMeta.source = isTmdb ? 'tmdb' : source;
           item._zoroMeta.mediaType = config.mediaType || 'ANIME';
           item._zoroMeta.fetchedAt = Date.now();
+          item._zoroMeta.isTrending = true;
         }
       });
 
@@ -503,7 +505,8 @@ class Trending {
       this.plugin.render.renderSearchResults(el, items, {
         layout: config.layout || 'card',
         mediaType: config.mediaType || 'ANIME',
-        source: source
+        source: source,
+        isTrending: true
       });
 
     } catch (err) {

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -471,6 +471,8 @@ class Trending {
 
   async renderTrendingBlock(el, config) {
     el.empty();
+    // Mark this container as a trending context for downstream DOM-based detection
+    try { el.classList.add('zoro-trending-context'); } catch {}
     el.appendChild(this.plugin.render.createListSkeleton(10));
 
     try {

--- a/src/rendering/renderers/CardRenderer.js
+++ b/src/rendering/renderers/CardRenderer.js
@@ -43,6 +43,10 @@ class CardRenderer {
     const card = document.createElement('div');
     card.className = `zoro-card ${isCompact ? 'compact' : ''}`;
     card.dataset.mediaId = String(Number(media.id) || 0);
+    // Propagate trending context via data attribute if provided
+    try {
+      if (options?.isTrending) card.dataset.trending = 'true';
+    } catch {}
 
     // Create cover image if enabled
     if (this.plugin.settings.showCoverImages && media.coverImage?.large) {

--- a/src/rendering/renderers/SearchRenderer.js
+++ b/src/rendering/renderers/SearchRenderer.js
@@ -93,7 +93,7 @@ class SearchRenderer {
     const fragment = document.createDocumentFragment();
     
     media.forEach(item => {
-      fragment.appendChild(this.cardRenderer.createMediaCard(item, config, { isSearch: true }));
+      fragment.appendChild(this.cardRenderer.createMediaCard(item, config, { isSearch: true, isTrending: Boolean(config?.isTrending) }));
     });
     
     grid.appendChild(fragment);


### PR DESCRIPTION
Update connected note code block suppression to correctly identify and exclude trending Movie/TV entries.

The previous logic for suppressing code blocks for trending Movie/TV entries incorrectly relied on the `source` being 'tmdb'. This PR modifies the trending renderer to explicitly tag items as `isTrending` and updates the connected notes feature to suppress code blocks when the media type is Movie/TV and the item is marked as trending, independent of its source.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b8b833d-72f3-4709-bc94-824a2ce2739d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b8b833d-72f3-4709-bc94-824a2ce2739d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

