### PR TITLE
Fix search add button for simkl movies and tv

### DIFF
--- a/cmp/main.js
+++ b/cmp/main.js
@@ -4802,6 +4802,18 @@ getSimklMediaType(mediaType) {
           
           // Only include items with valid IDs for editing operations
           if (mapped && mapped.id > 0) {
+            // Add _zoroMeta to ensure add button functionality works properly
+            if (!mapped._zoroMeta) {
+              mapped._zoroMeta = {
+                source: 'simkl',
+                mediaType: c.type,
+                fetchedAt: Date.now()
+              };
+            } else {
+              mapped._zoroMeta.source = 'simkl';
+              mapped._zoroMeta.mediaType = c.type;
+              mapped._zoroMeta.fetchedAt = Date.now();
+            }
             aggregated.push(mapped);
           }
         }
@@ -4910,6 +4922,18 @@ getSimklMediaType(mediaType) {
     for (const item of searchResults.Page.media) {
       if (item && item.id > 0) {
         // Item already has a valid ID
+        // Ensure _zoroMeta is set for add button functionality
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: mediaType,
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = mediaType;
+          item._zoroMeta.fetchedAt = Date.now();
+        }
         enhancedResults.push(item);
       } else if (item && item.title) {
         // Try to resolve ID by title
@@ -4918,6 +4942,18 @@ getSimklMediaType(mediaType) {
           const resolvedId = await this.resolveSimklIdByTitle(item.title, mediaType);
           if (resolvedId) {
             item.id = resolvedId;
+            // Ensure _zoroMeta is set for add button functionality
+            if (!item._zoroMeta) {
+              item._zoroMeta = {
+                source: 'simkl',
+                mediaType: mediaType,
+                fetchedAt: Date.now()
+              };
+            } else {
+              item._zoroMeta.source = 'simkl';
+              item._zoroMeta.mediaType = mediaType;
+              item._zoroMeta.fetchedAt = Date.now();
+            }
             enhancedResults.push(item);
             resolvedCount++;
             console.log(`[Simkl] Successfully resolved ID ${resolvedId} for "${item.title}"`);
@@ -4963,6 +4999,18 @@ getSimklMediaType(mediaType) {
     
     // If it already has a valid ID, return as is
     if (searchResult.id && Number.isFinite(Number(searchResult.id)) && Number(searchResult.id) > 0) {
+      // Ensure _zoroMeta is set for add button functionality
+      if (!searchResult._zoroMeta) {
+        searchResult._zoroMeta = {
+          source: 'simkl',
+          mediaType: mediaType,
+          fetchedAt: Date.now()
+        };
+      } else {
+        searchResult._zoroMeta.source = 'simkl';
+        searchResult._zoroMeta.mediaType = mediaType;
+        searchResult._zoroMeta.fetchedAt = Date.now();
+      }
       return searchResult;
     }
     
@@ -4972,6 +5020,18 @@ getSimklMediaType(mediaType) {
         const resolvedId = await this.resolveSimklIdByTitle(searchResult.title, mediaType);
         if (resolvedId) {
           searchResult.id = resolvedId;
+          // Ensure _zoroMeta is set for add button functionality
+          if (!searchResult._zoroMeta) {
+            searchResult._zoroMeta = {
+              source: 'simkl',
+              mediaType: mediaType,
+              fetchedAt: Date.now()
+            };
+          } else {
+            searchResult._zoroMeta.source = 'simkl';
+            searchResult._zoroMeta.mediaType = mediaType;
+            searchResult._zoroMeta.fetchedAt = Date.now();
+          }
           console.log(`[Simkl] Resolved ID ${resolvedId} for editing: "${searchResult.title}"`);
           return searchResult;
         }
@@ -5034,7 +5094,22 @@ getSimklMediaType(mediaType) {
     
     const transformedItems = items
       .map(item => this.transformMedia(item, config.mediaType))
-      .filter(item => item && item.id > 0); // Only include items with valid IDs for editing operations
+      .filter(item => item && item.id > 0) // Only include items with valid IDs for editing operations
+      .map(item => {
+        // Add _zoroMeta to ensure add button functionality works properly
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: config.mediaType || 'ANIME',
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+          item._zoroMeta.fetchedAt = Date.now();
+        }
+        return item;
+      });
     
     return {
       Page: {

--- a/cmp/main.js
+++ b/cmp/main.js
@@ -13652,6 +13652,7 @@ class Trending {
         },
         releaseDate: isMovie ? item.release_date : item.first_air_date,
         _zoroMeta: {
+          source: 'tmdb', // Add the source field to identify TMDB trending items
           mediaType: mediaType.toUpperCase(),
           fetchedAt: Date.now(),
           trending: {
@@ -13870,16 +13871,16 @@ class Trending {
       );
 
       items.forEach(item => {
-        const isTmdb = ['MOVIE','MOVIES','TV','SHOW','SHOWS'].includes((config.mediaType || '').toUpperCase());
+        const isTmdb = ['MOVIE','MOVIES','TV','SHOW','SHOWS'].includes(normalizedType.toUpperCase());
         if (!item._zoroMeta) {
           item._zoroMeta = {
             source: isTmdb ? 'tmdb' : source,
-            mediaType: config.mediaType || 'ANIME',
+            mediaType: normalizedType.toUpperCase(),
             fetchedAt: Date.now()
           };
         } else {
           item._zoroMeta.source = isTmdb ? 'tmdb' : source;
-          item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+          item._zoroMeta.mediaType = normalizedType.toUpperCase();
           item._zoroMeta.fetchedAt = Date.now();
         }
       });

--- a/main.js
+++ b/main.js
@@ -6948,6 +6948,7 @@ var Trending = class {
         },
         releaseDate: isMovie ? item.release_date : item.first_air_date,
         _zoroMeta: {
+          source: 'tmdb', // Add the source field to identify TMDB trending items
           mediaType: mediaType.toUpperCase(),
           fetchedAt: Date.now(),
           trending: {
@@ -7127,16 +7128,16 @@ var Trending = class {
         () => this.fetchTrending(source, normalizedType, limit)
       );
       items.forEach((item) => {
-        const isTmdb = ["MOVIE", "MOVIES", "TV", "SHOW", "SHOWS"].includes((config.mediaType || "").toUpperCase());
+        const isTmdb = ["MOVIE", "MOVIES", "TV", "SHOW", "SHOWS"].includes(normalizedType.toUpperCase());
         if (!item._zoroMeta) {
           item._zoroMeta = {
             source: isTmdb ? "tmdb" : source,
-            mediaType: config.mediaType || "ANIME",
+            mediaType: normalizedType.toUpperCase(),
             fetchedAt: Date.now()
           };
         } else {
           item._zoroMeta.source = isTmdb ? "tmdb" : source;
-          item._zoroMeta.mediaType = config.mediaType || "ANIME";
+          item._zoroMeta.mediaType = normalizedType.toUpperCase();
           item._zoroMeta.fetchedAt = Date.now();
         }
       });

--- a/main.js
+++ b/main.js
@@ -3920,6 +3920,18 @@ var SimklApi = class {
         for (const item of items) {
           const mapped = this.transformMedia(item, c.type);
           if (mapped && mapped.id > 0) {
+            // Add _zoroMeta to ensure add button functionality works properly
+            if (!mapped._zoroMeta) {
+              mapped._zoroMeta = {
+                source: 'simkl',
+                mediaType: c.type,
+                fetchedAt: Date.now()
+              };
+            } else {
+              mapped._zoroMeta.source = 'simkl';
+              mapped._zoroMeta.mediaType = c.type;
+              mapped._zoroMeta.fetchedAt = Date.now();
+            }
             aggregated.push(mapped);
           }
         }
@@ -3996,6 +4008,18 @@ var SimklApi = class {
     let resolvedCount = 0;
     for (const item of searchResults.Page.media) {
       if (item && item.id > 0) {
+        // Ensure _zoroMeta is set for add button functionality
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: mediaType,
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = mediaType;
+          item._zoroMeta.fetchedAt = Date.now();
+        }
         enhancedResults.push(item);
       } else if (item && item.title) {
         try {
@@ -4003,6 +4027,18 @@ var SimklApi = class {
           const resolvedId = await this.resolveSimklIdByTitle(item.title, mediaType);
           if (resolvedId) {
             item.id = resolvedId;
+            // Ensure _zoroMeta is set for add button functionality
+            if (!item._zoroMeta) {
+              item._zoroMeta = {
+                source: 'simkl',
+                mediaType: mediaType,
+                fetchedAt: Date.now()
+              };
+            } else {
+              item._zoroMeta.source = 'simkl';
+              item._zoroMeta.mediaType = mediaType;
+              item._zoroMeta.fetchedAt = Date.now();
+            }
             enhancedResults.push(item);
             resolvedCount++;
             console.log(`[Simkl] Successfully resolved ID ${resolvedId} for "${item.title}"`);
@@ -4040,6 +4076,18 @@ var SimklApi = class {
   async validateSearchResultForEditing(searchResult, mediaType) {
     if (!searchResult) return null;
     if (searchResult.id && Number.isFinite(Number(searchResult.id)) && Number(searchResult.id) > 0) {
+      // Ensure _zoroMeta is set for add button functionality
+      if (!searchResult._zoroMeta) {
+        searchResult._zoroMeta = {
+          source: 'simkl',
+          mediaType: mediaType,
+          fetchedAt: Date.now()
+        };
+      } else {
+        searchResult._zoroMeta.source = 'simkl';
+        searchResult._zoroMeta.mediaType = mediaType;
+        searchResult._zoroMeta.fetchedAt = Date.now();
+      }
       return searchResult;
     }
     if (searchResult.title) {
@@ -4047,6 +4095,18 @@ var SimklApi = class {
         const resolvedId = await this.resolveSimklIdByTitle(searchResult.title, mediaType);
         if (resolvedId) {
           searchResult.id = resolvedId;
+          // Ensure _zoroMeta is set for add button functionality
+          if (!searchResult._zoroMeta) {
+            searchResult._zoroMeta = {
+              source: 'simkl',
+              mediaType: mediaType,
+              fetchedAt: Date.now()
+            };
+          } else {
+            searchResult._zoroMeta.source = 'simkl';
+            searchResult._zoroMeta.mediaType = mediaType;
+            searchResult._zoroMeta.fetchedAt = Date.now();
+          }
           console.log(`[Simkl] Resolved ID ${resolvedId} for editing: "${searchResult.title}"`);
           return searchResult;
         }
@@ -4091,7 +4151,24 @@ var SimklApi = class {
         }
       }
     }
-    const transformedItems = items.map((item) => this.transformMedia(item, config.mediaType)).filter((item) => item && item.id > 0);
+    const transformedItems = items
+      .map((item) => this.transformMedia(item, config.mediaType))
+      .filter((item) => item && item.id > 0)
+      .map(item => {
+        // Add _zoroMeta to ensure add button functionality works properly
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: config.mediaType || 'ANIME',
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+          item._zoroMeta.fetchedAt = Date.now();
+        }
+        return item;
+      });
     return {
       Page: {
         media: transformedItems

--- a/src/api/services/SimklApi.js
+++ b/src/api/services/SimklApi.js
@@ -373,6 +373,18 @@ getSimklMediaType(mediaType) {
           
           // Only include items with valid IDs for editing operations
           if (mapped && mapped.id > 0) {
+            // Add _zoroMeta to ensure add button functionality works properly
+            if (!mapped._zoroMeta) {
+              mapped._zoroMeta = {
+                source: 'simkl',
+                mediaType: c.type,
+                fetchedAt: Date.now()
+              };
+            } else {
+              mapped._zoroMeta.source = 'simkl';
+              mapped._zoroMeta.mediaType = c.type;
+              mapped._zoroMeta.fetchedAt = Date.now();
+            }
             aggregated.push(mapped);
           }
         }
@@ -481,6 +493,18 @@ getSimklMediaType(mediaType) {
     for (const item of searchResults.Page.media) {
       if (item && item.id > 0) {
         // Item already has a valid ID
+        // Ensure _zoroMeta is set for add button functionality
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: mediaType,
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = mediaType;
+          item._zoroMeta.fetchedAt = Date.now();
+        }
         enhancedResults.push(item);
       } else if (item && item.title) {
         // Try to resolve ID by title
@@ -489,6 +513,18 @@ getSimklMediaType(mediaType) {
           const resolvedId = await this.resolveSimklIdByTitle(item.title, mediaType);
           if (resolvedId) {
             item.id = resolvedId;
+            // Ensure _zoroMeta is set for add button functionality
+            if (!item._zoroMeta) {
+              item._zoroMeta = {
+                source: 'simkl',
+                mediaType: mediaType,
+                fetchedAt: Date.now()
+              };
+            } else {
+              item._zoroMeta.source = 'simkl';
+              item._zoroMeta.mediaType = mediaType;
+              item._zoroMeta.fetchedAt = Date.now();
+            }
             enhancedResults.push(item);
             resolvedCount++;
             console.log(`[Simkl] Successfully resolved ID ${resolvedId} for "${item.title}"`);
@@ -534,6 +570,18 @@ getSimklMediaType(mediaType) {
     
     // If it already has a valid ID, return as is
     if (searchResult.id && Number.isFinite(Number(searchResult.id)) && Number(searchResult.id) > 0) {
+      // Ensure _zoroMeta is set for add button functionality
+      if (!searchResult._zoroMeta) {
+        searchResult._zoroMeta = {
+          source: 'simkl',
+          mediaType: mediaType,
+          fetchedAt: Date.now()
+        };
+      } else {
+        searchResult._zoroMeta.source = 'simkl';
+        searchResult._zoroMeta.mediaType = mediaType;
+        searchResult._zoroMeta.fetchedAt = Date.now();
+      }
       return searchResult;
     }
     
@@ -543,6 +591,18 @@ getSimklMediaType(mediaType) {
         const resolvedId = await this.resolveSimklIdByTitle(searchResult.title, mediaType);
         if (resolvedId) {
           searchResult.id = resolvedId;
+          // Ensure _zoroMeta is set for add button functionality
+          if (!searchResult._zoroMeta) {
+            searchResult._zoroMeta = {
+              source: 'simkl',
+              mediaType: mediaType,
+              fetchedAt: Date.now()
+            };
+          } else {
+            searchResult._zoroMeta.source = 'simkl';
+            searchResult._zoroMeta.mediaType = mediaType;
+            searchResult._zoroMeta.fetchedAt = Date.now();
+          }
           console.log(`[Simkl] Resolved ID ${resolvedId} for editing: "${searchResult.title}"`);
           return searchResult;
         }
@@ -605,7 +665,22 @@ getSimklMediaType(mediaType) {
     
     const transformedItems = items
       .map(item => this.transformMedia(item, config.mediaType))
-      .filter(item => item && item.id > 0); // Only include items with valid IDs for editing operations
+      .filter(item => item && item.id > 0) // Only include items with valid IDs for editing operations
+      .map(item => {
+        // Add _zoroMeta to ensure add button functionality works properly
+        if (!item._zoroMeta) {
+          item._zoroMeta = {
+            source: 'simkl',
+            mediaType: config.mediaType || 'ANIME',
+            fetchedAt: Date.now()
+          };
+        } else {
+          item._zoroMeta.source = 'simkl';
+          item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+          item._zoroMeta.fetchedAt = Date.now();
+        }
+        return item;
+      });
     
     return {
       Page: {

--- a/src/features/Trending.js
+++ b/src/features/Trending.js
@@ -267,6 +267,7 @@ class Trending {
         },
         releaseDate: isMovie ? item.release_date : item.first_air_date,
         _zoroMeta: {
+          source: 'tmdb', // Add the source field to identify TMDB trending items
           mediaType: mediaType.toUpperCase(),
           fetchedAt: Date.now(),
           trending: {
@@ -485,16 +486,16 @@ class Trending {
       );
 
       items.forEach(item => {
-        const isTmdb = ['MOVIE','MOVIES','TV','SHOW','SHOWS'].includes((config.mediaType || '').toUpperCase());
+        const isTmdb = ['MOVIE','MOVIES','TV','SHOW','SHOWS'].includes(normalizedType.toUpperCase());
         if (!item._zoroMeta) {
           item._zoroMeta = {
             source: isTmdb ? 'tmdb' : source,
-            mediaType: config.mediaType || 'ANIME',
+            mediaType: normalizedType.toUpperCase(),
             fetchedAt: Date.now()
           };
         } else {
           item._zoroMeta.source = isTmdb ? 'tmdb' : source;
-          item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+          item._zoroMeta.mediaType = normalizedType.toUpperCase();
           item._zoroMeta.fetchedAt = Date.now();
         }
       });

--- a/src/rendering/helpers/APISourceHelper.js
+++ b/src/rendering/helpers/APISourceHelper.js
@@ -57,7 +57,7 @@ class APISourceHelper {
         perPage: 5 
       });
     } else if (normalizedSource === 'simkl') {
-      return await this.plugin.simklApi.fetchSimklData({ 
+      const searchResults = await this.plugin.simklApi.fetchSimklData({ 
         ...config, 
         type: 'search',
         search: term, 
@@ -65,6 +65,25 @@ class APISourceHelper {
         page: 1, 
         perPage: 5 
       });
+      
+      // Add _zoroMeta to search results for proper add button functionality
+      if (searchResults?.Page?.media && Array.isArray(searchResults.Page.media)) {
+        searchResults.Page.media.forEach(item => {
+          if (!item._zoroMeta) {
+            item._zoroMeta = {
+              source: 'simkl',
+              mediaType: config.mediaType || 'ANIME',
+              fetchedAt: Date.now()
+            };
+          } else {
+            item._zoroMeta.source = 'simkl';
+            item._zoroMeta.mediaType = config.mediaType || 'ANIME';
+            item._zoroMeta.fetchedAt = Date.now();
+          }
+        });
+      }
+      
+      return searchResults;
     } else {
       return await this.plugin.api.fetchAniListData({ 
         ...config, 

--- a/src/rendering/renderers/CardRenderer.js
+++ b/src/rendering/renderers/CardRenderer.js
@@ -352,8 +352,11 @@ class CardRenderer {
   let entrySource = this.apiHelper.detectSource(entry, config);
   const entryMediaType = this.apiHelper.detectMediaType(entry, config, media);
 
-  const isTmdbItem = (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb';
-  if (isTmdbItem) {
+  // Check if this is a TMDB trending item that should use TMDB ID
+  const isTmdbTrendingItem = (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb';
+  
+  if (isTmdbTrendingItem) {
+    // For TMDB trending items, route to SIMKL but use TMDB ID
     entrySource = 'simkl';
     try {
       const numericId = Number(media.id) || Number(media.idTmdb) || 0;
@@ -379,18 +382,23 @@ class CardRenderer {
     const isMovieOrTv = typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper.includes('SHOW');
 
     const updates = (entrySource === 'simkl' && isMovieOrTv)
-      ? { status: 'PLANNING', score: 0, _zUseTmdbId: true }
+      ? { status: 'PLANNING', score: 0, _zUseTmdbId: isTmdbTrendingItem }
       : { status: 'PLANNING', progress: 0 };
 
-    // For TMDb movie/TV routed to Simkl, call the same update path used by Simkl search
-    // but use the TMDb id instead of Simkl id
-    if (entrySource === 'simkl' && isTmdbItem && isMovieOrTv) {
-      const ids = { tmdb: Number(media.idTmdb || media.id) || undefined, imdb: media.idImdb || undefined };
-      if (typeof this.plugin?.simklApi?.updateMediaListEntryWithIds === 'function') {
-        await this.plugin.simklApi.updateMediaListEntryWithIds(ids, updates, entryMediaType);
+    // For TMDB trending items, use TMDB ID; for SIMKL search items, use SIMKL ID
+    if (entrySource === 'simkl' && isMovieOrTv) {
+      if (isTmdbTrendingItem) {
+        // TMDB trending item: use TMDB ID
+        const ids = { tmdb: Number(media.idTmdb || media.id) || undefined, imdb: media.idImdb || undefined };
+        if (typeof this.plugin?.simklApi?.updateMediaListEntryWithIds === 'function') {
+          await this.plugin.simklApi.updateMediaListEntryWithIds(ids, updates, entryMediaType);
+        } else {
+          const idFallback = Number(media.idTmdb || media.id) || 0;
+          await this.apiHelper.updateMediaListEntry(idFallback, updates, entrySource, entryMediaType);
+        }
       } else {
-        const idFallback = Number(media.idTmdb || media.id) || 0;
-        await this.apiHelper.updateMediaListEntry(idFallback, updates, entrySource, entryMediaType);
+        // SIMKL search item: use SIMKL ID
+        await this.apiHelper.updateMediaListEntry(media.id, updates, entrySource, entryMediaType);
       }
     } else {
       await this.apiHelper.updateMediaListEntry(media.id, updates, entrySource, entryMediaType);

--- a/src/rendering/renderers/CardRenderer.js
+++ b/src/rendering/renderers/CardRenderer.js
@@ -352,11 +352,14 @@ class CardRenderer {
   let entrySource = this.apiHelper.detectSource(entry, config);
   const entryMediaType = this.apiHelper.detectMediaType(entry, config, media);
 
-  // Check if this is a TMDB trending item that should use TMDB ID
-  const isTmdbTrendingItem = (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb';
+  // Check if this is a search item or trending item
+  // Search items come from SIMKL API and should use SIMKL ID
+  // Trending items come from TMDB API and should use TMDB ID
+  const isSearchItem = entry?.isSearch === true || config?.isSearch === true;
+  const isTrendingItem = !isSearchItem;
   
-  if (isTmdbTrendingItem) {
-    // For TMDB trending items, route to SIMKL but use TMDB ID
+  // For trending items (from TMDB), route to SIMKL but use TMDB ID
+  if (isTrendingItem && (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb') {
     entrySource = 'simkl';
     try {
       const numericId = Number(media.id) || Number(media.idTmdb) || 0;
@@ -382,12 +385,12 @@ class CardRenderer {
     const isMovieOrTv = typeUpper === 'MOVIE' || typeUpper === 'MOVIES' || typeUpper === 'TV' || typeUpper.includes('SHOW');
 
     const updates = (entrySource === 'simkl' && isMovieOrTv)
-      ? { status: 'PLANNING', score: 0, _zUseTmdbId: isTmdbTrendingItem }
+      ? { status: 'PLANNING', score: 0, _zUseTmdbId: isTrendingItem && (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb' }
       : { status: 'PLANNING', progress: 0 };
 
     // For TMDB trending items, use TMDB ID; for SIMKL search items, use SIMKL ID
     if (entrySource === 'simkl' && isMovieOrTv) {
-      if (isTmdbTrendingItem) {
+      if (isTrendingItem && (entry?._zoroMeta?.source || '').toLowerCase() === 'tmdb') {
         // TMDB trending item: use TMDB ID
         const ids = { tmdb: Number(media.idTmdb || media.id) || undefined, imdb: media.idImdb || undefined };
         if (typeof this.plugin?.simklApi?.updateMediaListEntryWithIds === 'function') {


### PR DESCRIPTION
Add `_zoroMeta` to SIMKL search results to fix the broken add button functionality.

The add button relies on the `_zoroMeta` object to identify the media item's source (e.g., 'simkl') and media type. This metadata was missing for SIMKL search results, causing the add button to fail silently, similar to a previous issue fixed for trending items. This PR ensures the necessary metadata is present across various search result processing stages.

---
<a href="https://cursor.com/background-agent?bcId=bc-efc1c1ad-ae23-4c4d-8a0b-50a2b02f9c58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efc1c1ad-ae23-4c4d-8a0b-50a2b02f9c58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

