### PR TITLE
Investigate panel overlay on side buttons

### DIFF
--- a/src/details/OpenDetailPanel.js
+++ b/src/details/OpenDetailPanel.js
@@ -30,10 +30,9 @@ class OpenDetailPanel {
 		} catch {}
 		// Only create a DOM panel when we actually have a container to mount into.
 		if (mountContainer && mountContainer.appendChild) {
-			const panel = this.renderer.createPanel(media, entry);
+			const panel = this.renderer.createPanel(media, entry, { inline: true });
 			this.currentPanel = panel;
-			panel.classList.add('zoro-inline');
-			this.renderer.positionPanel(panel, null);
+			// inline panel uses its own class, no positioning needed
 			const closeBtn = panel.querySelector('.panel-close-btn');
 			if (closeBtn) closeBtn.onclick = () => this.closePanel();
 			mountContainer.appendChild(panel);

--- a/src/details/RenderDetailPanel.js
+++ b/src/details/RenderDetailPanel.js
@@ -6,11 +6,12 @@ class RenderDetailPanel {
     this.plugin = plugin;
   }
 
-  createPanel(media, entry) {
+  createPanel(media, entry, options = {}) {
+    const inline = options?.inline === true;
     const fragment = document.createDocumentFragment();
     
     const panel = document.createElement('div');
-    panel.className = 'zoro-more-details-panel';
+    panel.className = inline ? 'zoro-details-inline' : 'zoro-more-details-panel';
 
     const content = document.createElement('div');
     content.className = 'panel-content';
@@ -50,11 +51,12 @@ class RenderDetailPanel {
 
     sections.forEach(section => content.appendChild(section));
 
-    const closeBtn = document.createElement('span');
-    closeBtn.className = 'panel-close-btn';
-    closeBtn.style.display = 'none';
-
-    panel.appendChild(closeBtn);
+    if (!inline) {
+      const closeBtn = document.createElement('span');
+      closeBtn.className = 'panel-close-btn';
+      closeBtn.style.display = 'none';
+      panel.appendChild(closeBtn);
+    }
     panel.appendChild(content);
 
     // Add copy functionality styles

--- a/src/editing/Edit.js
+++ b/src/editing/Edit.js
@@ -44,7 +44,7 @@ class Edit {
   }
 
   createEditModal(entry, onSave, onCancel, source = 'anilist') {
-    // Route to Side Panel inline always
+    // Force side panel inline; never produce an overlay/modal DOM here
     try {
       const media = entry?.media;
       const mediaType = entry?._zoroMeta?.mediaType || media?.type || media?.format || 'ANIME';

--- a/styles.css
+++ b/styles.css
@@ -2929,6 +2929,23 @@ body.theme-light .zoro-heart.favorited::before {
   max-height: none;
 }
 
+/* New inline-only details container replacing overlay modal */
+.zoro-details-inline {
+  position: relative;
+  max-width: 100%;
+  width: 100%;
+  max-height: none;
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  box-shadow: none;
+  padding: 0;
+}
+.zoro-details-inline .panel-content {
+  max-height: none;
+  overflow: visible;
+}
+
 /* Safety: when rendered inside the side panel, never overlay the toolbar */
 .zoro-side-panel { position: relative; }
 .zoro-side-panel .zoro-more-details-panel,

--- a/styles.css
+++ b/styles.css
@@ -2760,8 +2760,9 @@ body.theme-light .zoro-heart.favorited::before {
 
 /* Ensure toolbar sits above any embedded inline panels */
 .zoro-panel-toolbar {
-  position: relative;
-  z-index: 10;
+  position: sticky;
+  top: 0;
+  z-index: 1001;
   background: var(--background-primary);
 }
 
@@ -2927,6 +2928,19 @@ body.theme-light .zoro-heart.favorited::before {
 .zoro-inline .panel-content {
   max-height: none;
 }
+
+/* Safety: when rendered inside the side panel, never overlay the toolbar */
+.zoro-side-panel { position: relative; }
+.zoro-side-panel .zoro-more-details-panel,
+.zoro-side-panel .zoro-edit-modal {
+  position: static !important;
+  transform: none !important;
+  z-index: 0 !important;
+  box-shadow: none !important;
+}
+.zoro-side-panel .zoro-more-details-panel::before { display: none !important; }
+.zoro-side-panel .zoro-panel-embed { position: relative; z-index: 0; }
+.zoro-side-panel .zoro-panel-toolbar, .zoro-side-panel .zoro-panel-btn { pointer-events: auto; }
 
 /* Empty State */
 .zoro-note-empty-state {

--- a/styles.css
+++ b/styles.css
@@ -1888,7 +1888,7 @@ transparent 70%
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.2s ease;
-  z-index: 1000;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 4px;


### PR DESCRIPTION
Fix side panel buttons being unclickable or hidden by More Details and Edit panels.

The More Details panel could render as a fixed-position modal, and both panels could block clicks due to stacking context issues. This PR ensures the side panel toolbar remains sticky, visible, and clickable above any embedded panels by adjusting z-index and positioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-75230014-9398-416d-8f55-23aa2911b8a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75230014-9398-416d-8f55-23aa2911b8a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

